### PR TITLE
Corrected haxe paths for OS X 10.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ For `version`, you can use any git reference - a branch, a tag, a commit hash, e
 
 ### Known bugs
 
-When you use `haxelib run hvm` some installations actually use Haxe to compile/run haxelib, then haxelib runs and calls `haxe/lib/hvm/0.0.2/run.n`. This is all well and good, until `hvm` tries to replace the Haxe binary, and the OS complains.  A workaround is to use something along the lines of:
+When you use `haxelib run hvm` some installations actually use Haxe to compile/run haxelib, then haxelib runs and calls `/usr/local/lib/haxelib/hvm/0,0,2/run.n`. This is all well and good, until `hvm` tries to replace the Haxe binary, and the OS complains.  A workaround is to use something along the lines of:
 
-    sudo neko /usr/lib/haxe/lib/hvm/0,0,2/hvm.n --use development
+    sudo neko /usr/local/lib/haxelib/hvm/0,0,2/hvm.n --use development
 
 ### Implementation Details
 
@@ -51,7 +51,7 @@ When you use `haxelib run hvm` some installations actually use Haxe to compile/r
 * When `--set` is used, the compiled version and the standard library are copied to your system path. You may need to use `sudo` for this to work.
 * On Linux & Mac: 
 	* You will need the build dependencies installed already. See <http://haxe.org/documentation/introduction/building-haxe.html>
-	* This assumes you have your Haxe binary at `/usr/lib/haxe/haxe` and the standard library at `/usr/lib/haxe/std/`. It would be nice to make this configurable.
+	* This assumes you have your Haxe binary at `/usr/local/lib/haxe/haxe` and the standard library at `/usr/local/lib/haxe/std/`. It would be nice to make this configurable.
 	* This will place your repo in `~/.hvm/`, where `~` is your home directory, found using the `HOME` environment variable.
 * On Windows:
 	* We are lacking an implementation, but it should be dead easy. See <https://github.com/jasononeil/hvm/blob/master/src/hvm/platform/WinConfig.hx>. Pull requests welcome.

--- a/src/hvm/platform/UnixConfig.hx
+++ b/src/hvm/platform/UnixConfig.hx
@@ -16,8 +16,8 @@ class UnixConfig implements PlatformConfig {
 		hvmRepo = Sys.getEnv( 'HOME' ).addTrailingSlash() + '.hvm/';
 
 		// TODO: a better way to get these, check env variables or `path haxe` etc.
-		haxeBinary = '/usr/lib/haxe/haxe';
-		stdLib = '/usr/lib/haxe/std/';
+		haxeBinary = '/usr/local/lib/haxe/haxe';
+		stdLib = '/usr/local/lib/haxe/std/';
 	}
 
 	public function build() {


### PR DESCRIPTION
During installation of a Haxe version I'm getting this error on OS X 10.11:

```
cp: /usr/lib/haxe/haxe: No such file or directory
```

The correct path (since OS X 10.11) is `/usr/local/lib/haxe/haxe`.
